### PR TITLE
delete records individually for safety

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /libdns-godaddy.iml
 /.env
 /.idea/
+**unused**
+**secret**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.1] - 2022-11-13
+### Changed
+  - DeleteRecords() method now deletes records individually across multiple API calls for safety
+
+## [1.0.0] - 2022-01-26
+### Added
+  - initial commit

--- a/_example/main.go
+++ b/_example/main.go
@@ -3,9 +3,10 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/joho/godotenv"
 	"log"
 	"os"
+
+	"github.com/joho/godotenv"
 
 	godaddy "github.com/libdns/godaddy"
 	"github.com/libdns/libdns"


### PR DESCRIPTION
This PR changes the logic for the DeleteRecords() method so that it will now iterate through eligible records and send a separate API call to GoDaddy for each delete request. This change should be 100% compatible with the former logic. Additionally I have verified correct functionality in a bulk rotation tool that I use.

The previous logic would identify the slice of "remainder records" based on the user's request to eliminate a subset, and then send this slice of "remainder records" in one API call to GoDaddy. If that single GoDaddy call fails or has any problem, it could result in a disaster situation where large groups of records become missing. My thought is that with the atomic-style single deletes, the risk is reduced and specific to the delete records. This also leaves the "remainder records" alone which is safer (after all, those are the records you never intended to change at all).

Please feel free to critique or let me know if I've done anything wrong here. I apologize that I'm new to Github.
Thank you
