### PR TITLE
Fix for TTL not updating in GoDaddy - closes #4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.2] - ####-##-##
+## [1.0.2] - 2023-01-02
 ### Fixed
   - TTL settings are now properly updated in GoDaddy during AppendRecords() and SetRecords() calls
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - ####-##-##
+### Fixed
+  - TTL settings are now properly updated in GoDaddy during AppendRecords() and SetRecords() calls
+
 ## [1.0.1] - 2022-11-13
 ### Changed
   - DeleteRecords() method now deletes records individually across multiple API calls for safety

--- a/provider.go
+++ b/provider.go
@@ -99,6 +99,7 @@ func (p *Provider) AppendRecords(ctx context.Context, zone string, records []lib
 
 		type PostRecord struct {
 			Data string `json:"data"`
+			TTL  int    `json:"ttl"` // DEBUG
 		}
 
 		if record.TTL < time.Duration(600)*time.Second {
@@ -109,7 +110,7 @@ func (p *Provider) AppendRecords(ctx context.Context, zone string, records []lib
 		data, err := json.Marshal([]PostRecord{
 			{
 				Data: record.Value,
-				Ttl:  3600, // DEBUG
+				TTL:  3600, // DEBUG
 			},
 		})
 		if err != nil {

--- a/provider.go
+++ b/provider.go
@@ -103,11 +103,13 @@ func (p *Provider) AppendRecords(ctx context.Context, zone string, records []lib
 
 		if record.TTL < time.Duration(600)*time.Second {
 			record.TTL = time.Duration(600) * time.Second
+			log.Printf(">>>DEBUG: record.TTL was forcefully set to 600 seconds\n")
 		}
 
 		data, err := json.Marshal([]PostRecord{
 			{
 				Data: record.Value,
+				Ttl:  3600, // DEBUG
 			},
 		})
 		if err != nil {

--- a/provider.go
+++ b/provider.go
@@ -99,18 +99,17 @@ func (p *Provider) AppendRecords(ctx context.Context, zone string, records []lib
 
 		type PostRecord struct {
 			Data string `json:"data"`
-			TTL  int    `json:"ttl"` // DEBUG
+			TTL  int    `json:"ttl"`
 		}
 
 		if record.TTL < time.Duration(600)*time.Second {
 			record.TTL = time.Duration(600) * time.Second
-			log.Printf(">>>DEBUG: record.TTL was forcefully set to 600 seconds\n")
 		}
 
 		data, err := json.Marshal([]PostRecord{
 			{
 				Data: record.Value,
-				TTL:  3600, // DEBUG
+				TTL:  int(record.TTL / time.Second),
 			},
 		})
 		if err != nil {


### PR DESCRIPTION
This PR is a fix for the TTL not being honored. I've also confirmed this fixed the issue and that custom TTL values are now properly updated in GoDaddy.

Thank you
