### PR TITLE
Multi-paging support for GetRecords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] - 2023-01-09
+### Fixed
+  - GetRecords now retrieves multiple pages of records automatically - if the total record count exceeds GoDaddy's per-API-call max of 500
+
 ## [1.0.2] - 2023-01-02
 ### Fixed
   - TTL settings are now properly updated in GoDaddy during AppendRecords() and SetRecords() calls

--- a/provider.go
+++ b/provider.go
@@ -93,7 +93,7 @@ func (p *Provider) GetRecords(ctx context.Context, zone string) ([]libdns.Record
 
 		// if no records returned, we've attempted to read beyond the final page
 		if len(resultObj) == 0 {
-			morePages = false // don't read any more pages
+			morePages = false // don't read any more pages; still return accumulated results
 			break
 		}
 
@@ -109,7 +109,7 @@ func (p *Provider) GetRecords(ctx context.Context, zone string) ([]libdns.Record
 
 		// if results returned were less than the max page size, then this was the final page
 		if len(resultObj) < RECORDPAGEMAX {
-			morePages = false // don't read any more pages
+			morePages = false // don't read any more pages; still return accumulated results
 			break
 		}
 	}

--- a/provider.go
+++ b/provider.go
@@ -16,6 +16,11 @@ import (
 	"github.com/libdns/libdns"
 )
 
+const (
+	// RECORDPAGEMAX is the maximum number of records that can be returned per API call/
+	RECORDPAGEMAX = 500
+)
+
 // Provider godaddy dns provider
 type Provider struct {
 	APIToken string `json:"api_token,omitempty"`
@@ -37,32 +42,8 @@ func (p *Provider) getApiHost() string {
 func (p *Provider) GetRecords(ctx context.Context, zone string) ([]libdns.Record, error) {
 	log.Println("GetRecords", zone)
 	client := http.Client{}
-
 	domain := getDomain(zone)
-
-	req, err := http.NewRequest(http.MethodGet, p.getApiHost()+"/v1/domains/"+domain+"/records", nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Add("Authorization", "sso-key "+p.APIToken)
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		bodyBytes, _ := ioutil.ReadAll(resp.Body)
-		return nil, fmt.Errorf("could not get records: Domain: %s; Status: %v; Body: %s",
-			domain, resp.StatusCode, string(bodyBytes))
-	}
-
-	result, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-
+	var records []libdns.Record
 	resultObj := []struct {
 		Type  string `json:"type"`
 		Name  string `json:"name"`
@@ -70,20 +51,67 @@ func (p *Provider) GetRecords(ctx context.Context, zone string) ([]libdns.Record
 		TTL   int    `json:"ttl"`
 	}{}
 
-	err = json.Unmarshal(result, &resultObj)
-	if err != nil {
-		return nil, err
-	}
+	// retrieve pages of up to 500 records each; continue incrementing the page counter
+	// until the record count drops below the max 500 (final page)
+	morePages := true
+	for page := 1; morePages; page++ {
+		url := p.getApiHost() + "/v1/domains/" + domain + "/records?offset=" + fmt.Sprint(page) + "&limit=" + fmt.Sprint(RECORDPAGEMAX)
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Add("Authorization", "sso-key "+p.APIToken)
+		req.Header.Set("Accept", "application/json")
 
-	var records []libdns.Record
+		resp, err := client.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		defer resp.Body.Close()
 
-	for _, record := range resultObj {
-		records = append(records, libdns.Record{
-			Type:  record.Type,
-			Name:  record.Name,
-			Value: record.Value,
-			TTL:   time.Duration(record.TTL) * time.Second,
-		})
+		// successful page retrieval returns code 200; attempting a page beyond the final sometimes returns code 422 UnprocessableEntity
+		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusUnprocessableEntity {
+			bodyBytes, _ := ioutil.ReadAll(resp.Body)
+			return nil, fmt.Errorf("could not get records: Domain: %s; Status: %v; Body: %s",
+				domain, resp.StatusCode, string(bodyBytes))
+		}
+
+		if resp.StatusCode == http.StatusUnprocessableEntity {
+			morePages = false // don't read any more pages; still return accumulated results
+			break
+		}
+
+		result, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+
+		err = json.Unmarshal(result, &resultObj)
+		if err != nil {
+			return nil, err
+		}
+
+		// if no records returned, we've attempted to read beyond the final page
+		if len(resultObj) == 0 {
+			morePages = false // don't read any more pages
+			break
+		}
+
+		// accumulate all records retrieved in the current page
+		for _, record := range resultObj {
+			records = append(records, libdns.Record{
+				Type:  record.Type,
+				Name:  record.Name,
+				Value: record.Value,
+				TTL:   time.Duration(record.TTL) * time.Second,
+			})
+		}
+
+		// if results returned were less than the max page size, then this was the final page
+		if len(resultObj) < RECORDPAGEMAX {
+			morePages = false // don't read any more pages
+			break
+		}
 	}
 
 	return records, nil


### PR DESCRIPTION
This PR fixes an issue I ran into working with large DNS zones that exceed 500 records. GoDaddy limits max records per API-call to 500, so the prior logic was only returning page 1 of the results. I've added some looping logic to dynamically retrieve additional pages.

Oddly... the documentation published by GoDaddy is confusing and/or incorrect about how their system behaves. After a lot of trial and error, I determined that their system is working like this:

- you can append to the query URL `?offset=0&limit=500` (note: not documented)
- the `offset` value works as a page number, and page numbering starts at 1 (note: not documented)
- the logic I've found that works is to keep incrementing the `offset` as long as you keep getting the max page size back; therefore, the first page coming back that is less than max would be the final page

These changes should be 100% compatible with the previous use of GetRecords(). I've also confirmed correct behavior for zones that contain more than 500 records.

Thank you
